### PR TITLE
Got Tests to Run with Mocha.

### DIFF
--- a/Brocfile.js
+++ b/Brocfile.js
@@ -63,6 +63,14 @@ var sinonFiles = pickFiles('vendor', {
     destDir: '/assets/'
   });
 
+var sinonChaiFiles = pickFiles('vendor', {
+    srcDir: '/sinon-chai/lib',
+    files: [
+      'sinon-chai.js'
+    ],
+    destDir: '/assets/'
+  });
+
 var mochaAdapter = pickFiles('vendor', {
     srcDir: '/ember-mocha-adapter',
     files: [
@@ -71,7 +79,7 @@ var mochaAdapter = pickFiles('vendor', {
     destDir: '/assets/'
   });
 
-var testTrees = mergeTrees([mochaFiles, mochaAdapter, chaiFiles, sinonFiles], {
+var testTrees = mergeTrees([mochaFiles, mochaAdapter, chaiFiles, sinonFiles, sinonChaiFiles], {
      overwrite: true
 });
 

--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,7 @@
     "ember-qunit": "https://github.com/WMeldon/ember-qunit.git#mocha",
     "mocha": "~1.17.0",
     "chai": "~1.9.1",
-    "sinon": "~1.10.0",
+    "sinonjs-built": "~1.7.3",
     "sinon-chai": "~2.5.0",
     "ember-mocha-adapter": "https://github.com/WMeldon/ember-mocha-adapter.git#qunit"
   }

--- a/tests/acceptance/test-loading-test.js
+++ b/tests/acceptance/test-loading-test.js
@@ -1,7 +1,6 @@
-var expect = require('chai').expect;
 
-describe('Mocha/Chai setup', function(){ 
-  it('Works', function(){
-    expect(1+1).to.equal(2);
-  });
+suite('Mocha/Chai setup');
+
+test('Works', function(){
+  chai.expect(1+1).to.equal(2);
 });

--- a/tests/index.html
+++ b/tests/index.html
@@ -30,8 +30,8 @@
     </style>
   </head>
   <body>
-    <div id="qunit"></div>
-    <div id="qunit-fixture"></div>
+
+    <div id="mocha"></div>
 
     <script>
       window.ParticipateFrontendENV = {{ENV}};


### PR DESCRIPTION
So the issue was that there were various failures that `ember test` wasn't letting you know about.  

The first (and easiest) was just a 404 on the sinon-chai file.  Just needed to add another bit to the Brocfile. I also switched over to using a built version of sinon as the main repo doesn't come prebuilt.  

The final issue, which was the real cause of your woes, was that you were trying to use the BDD style of Mocha and I never got around to porting that bit.  I only ever did the TDD style (see [this](http://visionmedia.github.io/mocha/#interfaces)).  

That last bit is the reason I never actually released my ember-mocha forks.  I just never got them all fully functional, just the bare minimum to prove it could be done.  

**Edit**
One last thing, I also removed the `require('chai')` as I believe that test are also going to use ES6 modules (ie `import Chai from 'chai'`) though I don't know if they support that so you'll probably just be best off sticking with Globals for now.
