### PR TITLE
Displays clickable list of issues that each open in new page. Test passes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+08/29/2014
+==========
+* [#43](https://github.com/oliverbarnes/participate-frontend/pull/43): Displays issues in a clickable list. Issue description is shown when a list item is toggled. (Closes issue [#25](https://github.com/oliverbarnes/participate-frontend/issues/25))
+
 08/26/2014
 ==========
 * Make a support and fix submit button 

--- a/app/controllers/issues/index.js
+++ b/app/controllers/issues/index.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+var IssuesIndexController = Ember.ArrayController.extend({
+
+});
+
+export default IssuesIndexController;

--- a/app/controllers/issues/issue.js
+++ b/app/controllers/issues/issue.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+var IssueController = Ember.ObjectController.extend({
+
+  actions: {
+    toggleExpand: function() {
+      this.toggleProperty('isExpanded');
+    }
+  },
+
+  isExpanded: false
+
+});
+
+export default IssueController;

--- a/app/router.js
+++ b/app/router.js
@@ -13,7 +13,9 @@ Router.map(function() {
       });
     }); 
   });
-  this.resource('issues');
+  this.resource('issues', { path: '/issues' }, function() {
+    this.route('issue', { path: '/:issue_id' });
+  });
 });
 
 export default Router;

--- a/app/routes/issues/index.js
+++ b/app/routes/issues/index.js
@@ -1,9 +1,10 @@
 import Ember from 'ember';
 
-var IssuesRoute = Ember.Route.extend({
+var IssuesIndexRoute = Ember.Route.extend({
   model: function() {
     return this.store.find('issue');
   }
+
 });
 
-export default IssuesRoute;
+export default IssuesIndexRoute;

--- a/app/routes/issues/issue.js
+++ b/app/routes/issues/issue.js
@@ -1,0 +1,11 @@
+import Ember from 'ember';
+
+var IssueRoute = Ember.Route.extend({
+
+  model: function(params) {
+    return this.store.find('issue', params.issue_id);
+  }
+
+});
+
+export default IssueRoute;

--- a/app/templates/issues.emblem
+++ b/app/templates/issues.emblem
@@ -1,5 +1,0 @@
-h2 List of issues
-
-ul.issues
-  each model
-    li.issue #{title}

--- a/app/templates/issues/index.emblem
+++ b/app/templates/issues/index.emblem
@@ -1,0 +1,9 @@
+
+h2 List of issues
+
+ul.issues
+  each model itemController="issues/issue"
+    li.issue
+      a click="toggleExpand" #{title}
+      if isExpanded
+        p.description #{description}

--- a/app/templates/issues/issue.emblem
+++ b/app/templates/issues/issue.emblem
@@ -1,0 +1,9 @@
+h1 Issue
+
+.title
+  h2
+    = title
+
+.description
+  p
+    = description

--- a/tests/acceptance/viewing-an-issue-test.js
+++ b/tests/acceptance/viewing-an-issue-test.js
@@ -1,0 +1,65 @@
+import startApp from 'participate-frontend/tests/helpers/start-app';
+import Resolver from 'participate-frontend/tests/helpers/resolver';
+
+var App;
+
+var expect = chai.expect
+
+suite('Viewing an issue', {
+  setup: function(){
+    App = startApp();
+  },
+  teardown: function() {
+    Ember.run(App, 'destroy');
+  }
+});
+
+test('Successfully', function(){
+  visit('/issues').then(function() {    
+    //test toggle of first issue and check that another description doesn't open
+    click( $("a:contains('What to do with the compensation money from the dam')") ).then(function() {
+      expect(currentURL()).to.equal('/issues');
+      expect(find('.description').text()).to.equal("The construction company in charge of the dam will pay 10 million in compensation to the local affected population. What to do with it?");
+      expect( $("a:contains('How to solve rising youth unemployment?')").length ).to.equal(1);
+      expect( $("a:contains('Youth unemployment in our community is high and continues to rise. How do we address this issue?')").length ).to.equal(0);
+    });
+    //test that re-toggling first issue closes the description
+    click( $("a:contains('What to do with the compensation money from the dam')") ).then(function() {
+      expect(currentURL()).to.equal('/issues');
+      expect(find('.issue').first().text()).to.equal("What to do with the compensation money from the dam\'s impact?");
+      expect( $("a:contains('The construction company in charge of the dam will pay 10 million in compensation to the local affected population. What to do with it?')").length ).to.equal(0);
+    });
+  });
+
+  visit('/issues').then(function() {
+    //test toggle of second issue and check that another description doesn't open
+    click( $("a:contains('How to solve rising youth unemployment?')") ).then(function() {
+      expect(currentURL()).to.equal('/issues');
+      expect(find('.description').text()).to.equal("Youth unemployment in our community is high and continues to rise. How do we address this issue?");
+      expect( $("a:contains('What to do with the compensation money from the dam')").length ).to.equal(1);
+      expect( $("a:contains('The construction company in charge of the dam will pay 10 million in compensation to the local affected population. What to do with it?')").length ).to.equal(0);
+    });
+    //test that re-toggling second issue closes the description
+    click( $("a:contains('How to solve rising youth unemployment?')") ).then(function() {
+      expect(currentURL()).to.equal('/issues');
+      expect( $("a:contains('How to solve rising youth unemployment?')").length ).to.equal(1);
+      expect( $("a:contains('Youth unemployment in our community is high and continues to rise. How do we address this issue?')").length ).to.equal(0);
+    });
+  });
+
+  visit('/issues').then(function() {
+    //test toggle of last issue and check that another description doesn't open
+    click( $("a:contains('What to do with the industrial wastelands next to the lake?')") ).then(function() {
+      expect(currentURL()).to.equal('/issues');
+      expect(find('.description').text()).to.equal("All the sugar refineries next to the lake closed down decades ago but their buildings and lands remain abandoned. How could they be re-integrated for public use?");
+      expect( $("a:contains('What to do with the compensation money from the dam')").length ).to.equal(1);
+      expect( $("a:contains('The construction company in charge of the dam will pay 10 million in compensation to the local affected population. What to do with it?')").length ).to.equal(0);
+    });
+    //test that re-toggling last issue closes the description
+    click( $("a:contains('What to do with the industrial wastelands next to the lake?')") ).then(function() {
+      expect(currentURL()).to.equal('/issues');
+      expect( $("a:contains('What to do with the industrial wastelands next to the lake?')").length ).to.equal(1);
+      expect( $("a:contains('All the sugar refineries next to the lake closed down decades ago but their buildings and lands remain abandoned. How could they be re-integrated for public use?')").length ).to.equal(0);
+    });
+  });
+});


### PR DESCRIPTION
@oliverbarnes : Issue titles are displayed in /issues in a list. The titles are hyperlinked to the individual issue page (e.g. /issues/1) which displays the title and description of the issue.

Do you want this, or do you want the issue to open up under the title as an expandable text when the user clicks on the title?
