### PR TITLE
Added more suggestions to suggestion model to test viewing suggestions

### DIFF
--- a/app/models/suggestion.js
+++ b/app/models/suggestion.js
@@ -17,6 +17,21 @@ Suggestion.reopenClass({
        id: 1,
        initiative: 1,
        details: "Make sure there's a doctor available for house calls"
+     },
+     {
+       id: 2,
+       initiative: 1,
+       details: "Set up a vaccination program."
+     },
+     {
+       id: 3,
+       initiative: 1,
+       details: "Collaborate with the neighbouring municipality to integrate services."
+     },
+     {
+       id: 4,
+       initiative: 2,
+       details: "Pay to ship the plastic to Sweden--it's cheaper than recycling it ourselves."
      }
    ]
 });


### PR DESCRIPTION
Code to show view suggestions bug: Added two more suggestions to initiative 1 in suggestions.js model, and one suggestion for initiative 2, but for initiative 1, only the first one is displayed when manually going to /initiatives/1/suggestions, and for initiative 2, no suggestions are displayed.
