### PR TITLE
Removed dirty hack in InitiativesNewRoute but need a hack in initiative....

### DIFF
--- a/app/routes/initiatives/new.js
+++ b/app/routes/initiatives/new.js
@@ -8,16 +8,11 @@ var InitiativesNewRoute = Ember.Route.extend({
   actions: {
     submit: function() {
       var _this = this,
-          content = this.controller.content,
-          initiative = this.get('controller.model');
+          initiative = this.get('controller.model'),
+          issue = this.store.createRecord('issue');
 
-      var issue = this.store.createRecord('issue', {
-                    //dirty hack, while figuring out why EasyForm isn't 
-                    // passing params to submit()
-                    title: content.issue_title,
-                    description: content.issue_description
-                  });
-      initiative.set('issue', issue);
+      issue.set('title', initiative.issue_title);
+      issue.set('description', initiative.issue_description);
       initiative.save().then(function(model) {
         _this.transitionTo('initiative', model.get('id'));
       });

--- a/app/templates/initiative.emblem
+++ b/app/templates/initiative.emblem
@@ -3,7 +3,8 @@
     = title
 
 .issue_title
-  p Issue: #{issue.title}
+  p Issue: #{issue.title}#{issue_title}
+   
 
 .description
   p


### PR DESCRIPTION
@oliverbarnes do you know what's going on here? In investigating issue #24, I came across the "dirty hack" in InitiativesNewRoute and found that it was not needed to store the issue data, except then the template needs two syntaxes to display the issue title depending on if the issue was created on the fly or if the issue is already in the model fixture data as a hard-wired issue. If the former, the template needs #{issue_title}, but if the latter, the template needs #{issue.title}.
